### PR TITLE
implement in-place update

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -20,3 +20,7 @@ disable=SC2004
 
 # redundant sed invocation
 disable=SC2001
+
+# referencing unassigned variable
+#  we need to reference magisk pre-set variables a lot
+disable=SC2154

--- a/magiskmodule/customize.sh
+++ b/magiskmodule/customize.sh
@@ -1,0 +1,20 @@
+#!/system/bin/sh
+
+exec 2>&1
+
+[ "$BOOTMODE" != "true" ] && abort "Please install this module within the Magisk app."
+
+# path to already installed module
+INSTALLEDMODPATH=/data/adb/modules/MagicalProtection
+
+[ ! -d "$INSTALLEDMODPATH" ] && return 0
+[ ! -w /system/etc/hosts ] && return 0
+
+ui_print "- Performing in-place update"
+
+cp -v -r -f "$MODPATH"/* "$INSTALLEDMODPATH"
+cp -v -f "$MODPATH"/system/etc/hosts /system/etc/hosts
+
+rm -v -r "$MODPATH"
+
+exit 0


### PR DESCRIPTION
- [x] current `INSTALLEDMODPATH` seems to be compatible with KSU and APATCH
- [x] use of `exit 0` at the end is dirty, but required in order for magisk to not [create the `update` file](https://github.com/topjohnwu/Magisk/blob/8506b672ad531306b6f168ae79e812696a4364d2/scripts/util_functions.sh#L707)
- [ ] ```test -w /system/etc/hosts``` works properly on LineageOS `bash`, but the Magisk standalone `ash` does not detect if a file is filesystem-writable but the enclosing filesystem itself is not mounted writable